### PR TITLE
Escrow SOL inheritance in PDA and enable signed claims

### DIFF
--- a/frontend/src/components/ClaimAssets.tsx
+++ b/frontend/src/components/ClaimAssets.tsx
@@ -97,6 +97,7 @@ export function ClaimAssets() {
             )[0],
             owner_account: ownerAccount,
             heir_account: publicKey,
+            system_program: web3.SystemProgram.programId,
           })
           .rpc();
         

--- a/frontend/src/lib/anchor.ts
+++ b/frontend/src/lib/anchor.ts
@@ -62,8 +62,9 @@ const IDL: any = {
       "name": "claim_heir_coin_assets",
       "accounts": [
         { "name": "coinHeir", "isMut": true, "isSigner": false },
-        { "name": "ownerAccount", "isMut": true, "isSigner": false },
-        { "name": "heirAccount", "isMut": true, "isSigner": true }
+        { "name": "ownerAccount", "isMut": false, "isSigner": false },
+        { "name": "heirAccount", "isMut": true, "isSigner": true },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
       ],
       "args": []
     },
@@ -247,6 +248,7 @@ export async function claimHeirCoinAssets(
       coinHeir: coinHeirPDA,
       ownerAccount: ownerAccount,
       heirAccount: program.provider.publicKey!,
+      systemProgram: web3.SystemProgram.programId,
     })
     .rpc();
 }

--- a/gada/frontend/src/lib/anchor.ts
+++ b/gada/frontend/src/lib/anchor.ts
@@ -85,8 +85,9 @@ const IDL = {
       "name": "claim_heir_coin_assets",
       "accounts": [
         { "name": "coin_heir", "isMut": true, "isSigner": false },
-        { "name": "owner_account", "isMut": true, "isSigner": false },
-        { "name": "heir_account", "isMut": true, "isSigner": true }
+        { "name": "owner_account", "isMut": false, "isSigner": false },
+        { "name": "heir_account", "isMut": true, "isSigner": true },
+        { "name": "system_program", "isMut": false, "isSigner": false }
       ],
       "args": []
     },
@@ -340,6 +341,7 @@ export async function claimHeirCoinAssets(
       coinHeir: coinHeirPDA,
       ownerAccount: ownerAccount,
       heirAccount: program.provider.publicKey!,
+      systemProgram: web3.SystemProgram.programId,
     })
     .rpc();
 }


### PR DESCRIPTION
## Summary
- Escrow lamports in `coin_heir` PDA when adding a coin heir
- Allow heirs to claim SOL using `invoke_signed` from the PDA
- Expand client utilities and tests for funded PDAs and claim flow

## Testing
- `npx anchor test --skip-deploy` *(fails: Could not find globally installed anchor)*
- `cargo test` *(fails: lifetime may not live long enough)*

------
https://chatgpt.com/codex/tasks/task_e_68a9aef133288332bba2aa8bc4292a8c