### PR TITLE
chore: update program ID references

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ solana config set --url devnet
 anchor build
 anchor deploy
 ```
-- Ensure the program ID matches `Gf4b24oCZ6xGdVj5HyKfDBZKrd3JUuhQ87ApMAyg87t5` (see `Anchor.toml`).
+- Ensure the program ID matches `8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE` (see `Anchor.toml`).
 
 ### 4. Run the Frontends
 ```bash

--- a/deploy.sh
+++ b/deploy.sh
@@ -77,19 +77,19 @@ update_program_id() {
     
     # Update frontend configuration
     if [ -f "frontend/src/lib/publickey-utils.ts" ]; then
-        sed -i.bak "s/JDiDDsbcxy1389gGQw26nVSuyn6WuhauAFQkFiozEPdM/$PROGRAM_ID/g" frontend/src/lib/publickey-utils.ts
+        sed -i.bak "s/8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE/$PROGRAM_ID/g" frontend/src/lib/publickey-utils.ts
         print_success "Updated frontend configuration"
     fi
     
     # Update Anchor configuration
     if [ -f "gada/Anchor.toml" ]; then
-        sed -i.bak "s/JDiDDsbcxy1389gGQw26nVSuyn6WuhauAFQkFiozEPdM/$PROGRAM_ID/g" gada/Anchor.toml
+        sed -i.bak "s/8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE/$PROGRAM_ID/g" gada/Anchor.toml
         print_success "Updated Anchor configuration"
     fi
     
     # Update program lib.rs
     if [ -f "gada/programs/gada/src/lib.rs" ]; then
-        sed -i.bak "s/JDiDDsbcxy1389gGQw26nVSuyn6WuhauAFQkFiozEPdM/$PROGRAM_ID/g" gada/programs/gada/src/lib.rs
+        sed -i.bak "s/8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE/$PROGRAM_ID/g" gada/programs/gada/src/lib.rs
         print_success "Updated program source"
     fi
     

--- a/frontend/src/components/InheritanceManager.tsx
+++ b/frontend/src/components/InheritanceManager.tsx
@@ -146,7 +146,7 @@ export function InheritanceManager() {
           errorMessage += 'Invalid wallet address provided.';
         } else if (error.message.includes('program that does not exist') || error.message.includes('Attempt to load a program that does not exist')) {
           errorMessage += 'The Gado program is not deployed on this network. Please contact support or try again later.';
-          console.error('Program deployment issue - Program ID:', 'JDiDDsbcxy1389gGQw26nVSuyn6WuhauAFQkFiozEPdM', 'Network: Devnet');
+          console.error('Program deployment issue - Program ID:', '8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE', 'Network: Devnet');
         } else if (error.message.includes('Simulation failed')) {
           errorMessage += 'Transaction simulation failed. This usually means the program is not deployed or network issues. Please try again.';
         } else {

--- a/gada/DEPLOYMENT_GUIDE.md
+++ b/gada/DEPLOYMENT_GUIDE.md
@@ -56,7 +56,7 @@ If you can't deploy the program, you can temporarily mock the program calls for 
 
 ## Current Program Configuration
 
-- **Program ID:** `JDiDDsbcxy1389gGQw26nVSuyn6WuhauAFQkFiozEPdM` (Updated to match Anchor.toml)
+- **Program ID:** `8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE` (Updated to match Anchor.toml)
 - **Current Network:** Devnet (configured in Anchor.toml)
 - **Frontend Network:** Devnet (configured in WalletProvider.tsx)
 

--- a/gada/frontend/src/lib/anchor.ts
+++ b/gada/frontend/src/lib/anchor.ts
@@ -145,7 +145,7 @@ const IDL = {
 } as any; // Type assertion to bypass strict typing
 
 // Program ID from your IDL
-const PROGRAM_ID = new web3.PublicKey("JDiDDsbcxy1389gGQw26nVSuyn6WuhauAFQkFiozEPdM");
+const PROGRAM_ID = new web3.PublicKey("8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE");
 
 export function useAnchorProgram(): any {
   const { connection } = useConnection();

--- a/gada/frontend/src/lib/programCheck.ts
+++ b/gada/frontend/src/lib/programCheck.ts
@@ -1,6 +1,6 @@
 import { Connection, PublicKey } from '@solana/web3.js';
 
-const PROGRAM_ID = new PublicKey("JDiDDsbcxy1389gGQw26nVSuyn6WuhauAFQkFiozEPdM");
+const PROGRAM_ID = new PublicKey("8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE");
 
 export async function checkProgramDeployment(connection: Connection): Promise<boolean> {
   try {


### PR DESCRIPTION
## Summary
- replace outdated program ID in Quick Start
- sync Anchor config, deployment scripts, and frontends to use `8N4Mjyw7ThUFdkJ1LbrAnCzfxSpxknqCZhkGHDCcaMRE`

## Testing
- `npm run lint` (fails: React hooks/TypeScript warnings)
- `cd gada/frontend && npm run lint` (fails: TypeScript `any` usage)

------
https://chatgpt.com/codex/tasks/task_e_68a9aef7ce788332bd3811a9b5319144